### PR TITLE
Made it so gmtime accepts tm as a parameter

### DIFF
--- a/libc/include/time.h
+++ b/libc/include/time.h
@@ -18,7 +18,7 @@ typedef struct {
 } tm;
 
 /* Get the current date UTC */
-tm *gmtime(void);
+void gmtime(tm* time);
 
 /* Get the current date of the local time */
 tm *localtime(void);

--- a/libc/shell/shell.c
+++ b/libc/shell/shell.c
@@ -144,8 +144,13 @@ void shell_color(char** args){
 }
 
 void shell_date(char** args){
-    tm *time = gmtime();
-    printf("Date: %s | Time UTC: %s\n", time->date_str, time->time_str);
+    static tm time;
+    static char date_buffer[20];
+    static char time_buffer[20];
+    time.date_str = date_buffer;
+    time.time_str = time_buffer;
+    gmtime(&time);
+    printf("Date: %s | Time UTC: %s\n", time.date_str, time.time_str);
     
 }
 

--- a/libc/time/gmtime.c
+++ b/libc/time/gmtime.c
@@ -8,6 +8,4 @@
 void gmtime(tm* time){
     strcpy(time->date_buffer, get_date());
     strcpy(time->time_buffer, get_time());
-    time.date_str = date_buffer;
-    time.time_str = time_buffer;
 }

--- a/libc/time/gmtime.c
+++ b/libc/time/gmtime.c
@@ -5,15 +5,9 @@
 
 #include <drivers/rtc.h>
 
-tm *gmtime(void){
-    static tm time;
-    static char date_buffer[20];
-    static char time_buffer[20];
-    strcpy(date_buffer, get_date());
-    strcpy(time_buffer, get_time());
-
+void gmtime(tm* time){
+    strcpy(time->date_buffer, get_date());
+    strcpy(time->time_buffer, get_time());
     time.date_str = date_buffer;
     time.time_str = time_buffer;
-
-    return &time; 
 }

--- a/libc/time/gmtime.c
+++ b/libc/time/gmtime.c
@@ -6,6 +6,6 @@
 #include <drivers/rtc.h>
 
 void gmtime(tm* time){
-    strcpy(time->date_buffer, get_date());
-    strcpy(time->time_buffer, get_time());
+    strcpy(time->date_str, get_date());
+    strcpy(time->time_str, get_time());
 }


### PR DESCRIPTION
Made it so tm is accepted as a parameter, instead of using 'static' which limited it to being used only on one thread, by one function at a time.