### PR TITLE
Comment out undefined localtime and add comments

### DIFF
--- a/libc/include/time.h
+++ b/libc/include/time.h
@@ -18,10 +18,13 @@ typedef struct {
 } tm;
 
 /* Get the current date UTC */
+// NOTE: Not always 100% accurate as RTC can be re-programmed to use localtime instead of gmtime
+// Which is especially deceiving if there's another OS running/has been run before
 void gmtime(tm* time);
 
 /* Get the current date of the local time */
-tm *localtime(void);
+// TODO: localtime. Will require Time protocol and syncing with either LAN or a public time server (Not yet available, networking stack first).
+// tm *localtime(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Commented out localtime function, which isn't implemented (can cause issues on older gcc versions, if the declaration isn't stripped if not used). Also added explanation as to why localtime can't be implemented in its current state as we don't really have any networking stack or use a time protocol to sync the RTC clock (useful to have an explanation as to why)